### PR TITLE
Fix PDF export in desktop app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^24.12.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -608,6 +608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,6 +3311,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
+ "data-url",
  "dirs",
  "dunce",
  "embed_plist",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.6.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.11.2", features = [] }
+tauri = { version = "2.11.2", features = ["webview-data-url"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"
 url = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
   ],
   "permissions": [
     "core:default",
+    "core:webview:allow-create-webview-window",
+    "core:webview:allow-print",
     "dialog:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use tauri::State;
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 struct OpenedFiles(Mutex<Vec<PathBuf>>);
 

--- a/src/platform/fileAccess.test.ts
+++ b/src/platform/fileAccess.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const invoke = vi.fn()
+const webviewWindows: Array<{
+  label: string
+  options: { title?: string; url?: string }
+}> = []
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke,
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  WebviewWindow: class {
+    label: string
+    options: { title?: string; url?: string }
+
+    constructor(label: string, options: { title?: string; url?: string }) {
+      this.label = label
+      this.options = options
+      webviewWindows.push({ label, options })
+    }
+
+    async once(event: string, handler: (event: { payload?: unknown }) => void) {
+      if (event === 'tauri://created') {
+        window.setTimeout(() => handler({}), 0)
+      }
+      return vi.fn()
+    }
+  },
+}))
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}))
+
+describe('file access PDF export', () => {
+  beforeEach(() => {
+    invoke.mockReset()
+    webviewWindows.length = 0
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+    document.title = ''
+
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+  })
+
+  it('prints the exported markdown document through a dedicated Tauri window', async () => {
+    const { tauriFileAccess } = await import('./fileAccess')
+    const html = [
+      '<!doctype html>',
+      '<html>',
+      '<head><style>.markdown-preview { color: red; }</style></head>',
+      '<body><article class="markdown-preview"><h1>Printable</h1></article></body>',
+      '</html>',
+    ].join('')
+
+    await tauriFileAccess.printExportHtml(html, 'print.md')
+
+    expect(webviewWindows).toHaveLength(1)
+    expect(webviewWindows[0].options.title).toBe('print.md')
+    expect(decodeURIComponent(webviewWindows[0].options.url ?? '')).toContain('<h1>Printable</h1>')
+    expect(invoke).toHaveBeenCalledWith('plugin:webview|print', { label: webviewWindows[0].label })
+  })
+})

--- a/src/platform/fileAccess.ts
+++ b/src/platform/fileAccess.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { open, save } from '@tauri-apps/plugin-dialog'
 import { createExportHtmlDefaultPath } from '../domain/exportHtml'
 import { ensureMarkdownExtension } from './markdownFiles'
@@ -183,42 +184,54 @@ async function printHtmlDocument(html: string, title: string) {
     throw new Error('Printing is only available in a browser window.')
   }
 
-  const iframe = document.createElement('iframe')
-  iframe.title = title
-  iframe.setAttribute('aria-hidden', 'true')
-  iframe.style.position = 'fixed'
-  iframe.style.right = '0'
-  iframe.style.bottom = '0'
-  iframe.style.width = '0'
-  iframe.style.height = '0'
-  iframe.style.border = '0'
-  iframe.style.opacity = '0'
-  document.body.append(iframe)
-
-  try {
-    const iframeDocument = iframe.contentDocument ?? iframe.contentWindow?.document
-    if (!iframeDocument) {
-      throw new Error('Unable to create print document.')
-    }
-
-    iframeDocument.open()
-    iframeDocument.write(html)
-    iframeDocument.close()
-
-    await new Promise<void>((resolve) => window.setTimeout(resolve, 0))
-
-    const iframeWindow = iframe.contentWindow
-    if (!iframeWindow) {
-      throw new Error('Unable to open print window.')
-    }
-
-    iframeWindow.focus()
-    iframeWindow.print()
-    window.setTimeout(() => iframe.remove(), 1000)
-  } catch (error) {
-    iframe.remove()
-    throw error
+  if (isTauriRuntime()) {
+    await printHtmlInTauriWindow(html, title)
+    return
   }
+
+  const printWindow = window.open('', '_blank', 'popup,width=900,height=700')
+  if (!printWindow) {
+    throw new Error('Unable to open print window.')
+  }
+
+  printWindow.document.open()
+  printWindow.document.write(html)
+  printWindow.document.close()
+  printWindow.focus()
+  printWindow.print()
+}
+
+async function printHtmlInTauriWindow(html: string, title: string) {
+  const label = `pdf-export-${Date.now()}`
+  const printWindow = new WebviewWindow(label, {
+    title,
+    url: createHtmlDataUrl(html),
+    width: 900,
+    height: 700,
+    center: true,
+    resizable: true,
+    focus: true,
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = window.setTimeout(() => reject(new Error('Unable to open print window.')), 5000)
+
+    printWindow.once('tauri://created', () => {
+      window.clearTimeout(timeout)
+      resolve()
+    })
+    printWindow.once('tauri://error', (event) => {
+      window.clearTimeout(timeout)
+      reject(new Error(String(event.payload)))
+    })
+  })
+
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 500))
+  await invoke('plugin:webview|print', { label })
+}
+
+function createHtmlDataUrl(html: string): string {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
 }
 
 function isTauriRuntime(): boolean {


### PR DESCRIPTION
## Summary
- print exported Markdown from a dedicated Tauri window so PDF output contains only the rendered document
- allow WebView window creation/printing and data URLs for the desktop print flow
- add missing mdast types and desktop PDF export test

## Tests
- pnpm run test
- pnpm run build
- pnpm run desktop:build